### PR TITLE
fix: enable CORS for Vite frontend development

### DIFF
--- a/src/main/java/com/matthewbixby/allergen/intelligence/config/SecurityConfig.java
+++ b/src/main/java/com/matthewbixby/allergen/intelligence/config/SecurityConfig.java
@@ -16,6 +16,11 @@ import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.CorsConfigurationSource;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
+
+import java.util.List;
 
 @Configuration
 @EnableWebSecurity
@@ -29,9 +34,10 @@ public class SecurityConfig {
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
         http
                 .csrf(csrf -> csrf.disable())
-                .cors(cors -> cors.disable())
+                .cors(cors -> cors.configurationSource(corsConfigurationSource()))  // Enable CORS
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers("/api/auth/**").permitAll()
+                        .requestMatchers("/actuator/health").permitAll()
                         .requestMatchers("/api/allergen/**").authenticated()
                         .requestMatchers("/api/pubchem/**").authenticated()
                         .anyRequest().authenticated()
@@ -43,6 +49,37 @@ public class SecurityConfig {
                 .addFilterBefore(jwtAuthFilter, UsernamePasswordAuthenticationFilter.class);
 
         return http.build();
+    }
+
+    @Bean
+    public CorsConfigurationSource corsConfigurationSource() {
+        CorsConfiguration configuration = new CorsConfiguration();
+
+        // Allow frontend origins
+        configuration.setAllowedOrigins(List.of(
+                "http://localhost:5173",      // Vite default port
+                "http://localhost:3000",      // Alternative React port
+                "http://localhost:4173"       // Vite preview port
+        ));
+
+        // Allow necessary HTTP methods
+        configuration.setAllowedMethods(List.of(
+                "GET", "POST", "PUT", "DELETE", "OPTIONS"
+        ));
+
+        // Allow all headers (including Authorization)
+        configuration.setAllowedHeaders(List.of("*"));
+
+        // Allow credentials (needed for JWT tokens in Authorization header)
+        configuration.setAllowCredentials(true);
+
+        // How long browsers can cache preflight requests (1 hour)
+        configuration.setMaxAge(3600L);
+
+        // Apply CORS configuration to all endpoints
+        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+        source.registerCorsConfiguration("/**", configuration);
+        return source;
     }
 
     @Bean


### PR DESCRIPTION
- Add CORS configuration source bean with localhost:5173 support
- Allow GET, POST, PUT, DELETE, OPTIONS methods
- Enable credentials for JWT token authentication
- Add support for Vite dev (5173), React (3000), and preview (4173) ports
- Configure 1-hour preflight cache for performance

This enables the React/Vite frontend to communicate with the backend API without CORS errors during local development.